### PR TITLE
Cutover prep: policy pages, 404, blog redirects, CNAME

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -30,10 +30,33 @@ function rehypeBasePrefix() {
   };
 }
 
+// Legacy Jekyll permalink was `/:title` (posts at the site root). The Astro site
+// serves posts under `/blog/<slug>/`, so preserve inbound links / SEO by redirecting
+// each old root slug to its new location. Astro emits static meta-refresh pages for
+// these (GitHub Pages-compatible) and prepends `base` to the targets automatically.
+const blogRedirects = {
+  '/announcing-devito-pro-enterprise-edition-of-the-open-source-platform-devito': '/blog/launch',
+  '/thematrix-v02-the-devito-benchmark-matrix': '/blog/thematrix',
+  '/devito-cluster-the-whys-and-the-whats': '/blog/cluster',
+  '/devitopro-getting-hip-with-amd-instinct': '/blog/instinct',
+  '/devito-devops-cluster-v2': '/blog/cluster-v2',
+  '/cross-platform-seismic-imaging-benchmarking': '/blog/benchmarking',
+  '/devito-codes-on-the-road-to-image-2023': '/blog/image2023',
+  '/announcing-devitopro-sycl-code-generation': '/blog/sycl',
+  '/s-cube-integrates-devitopro-for-performance-portable-innovation': '/blog/s-cube',
+  '/announcing-devito-and-devitopro-v487': '/blog/v4.8.7',
+  '/announcing-judis-support-for-devitopro': '/blog/judi',
+  '/advancements-in-elastic-wave-solvers-using-devitopro-and-mixed-precision': '/blog/elastic',
+  '/seismic-imaging-performance-with-aws-graviton4': '/blog/graviton4',
+  '/accurate-and-robust-propogators-and-gradients-for-land-seismic-imaging': '/blog/IM',
+  '/benchmarking-devitopro-on-intel-xeon-6-processors': '/blog/granite',
+};
+
 export default defineConfig({
   site: SITE,
   base: BASE,
   trailingSlash: 'ignore',
+  redirects: blogRedirects,
   integrations: [sitemap()],
   markdown: { rehypePlugins: [rehypeBasePrefix] },
   vite: { plugins: [tailwindcss()] },

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+www.devitocodes.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -5,3 +5,5 @@ Disallow: /private/
 # per Zetafonts EULA 1wp3-855llosp / 94575. Do not crawl/index.
 Disallow: /fonts/
 Disallow: /_astro/
+
+Sitemap: https://www.devitocodes.com/sitemap-index.xml

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -26,6 +26,8 @@ const cols = [
     links: [
       { label: 'Code of Conduct', href: '/Code_of_Conduct' },
       { label: 'Data Protection Policy', href: '/Data_Protection_Policy' },
+      { label: 'Privacy Policy', href: '/privacy-policy' },
+      { label: 'Terms of Service', href: '/terms' },
     ],
   },
 ];

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,18 @@
+---
+import Base from '../layouts/Base.astro';
+import { withBase } from '../lib/url';
+---
+<Base title="Page not found" description="The page you were looking for could not be found.">
+  <section class="container-x py-32 text-center max-w-2xl mx-auto">
+    <p class="eyebrow">Error 404</p>
+    <h1 class="mt-3 text-5xl md:text-6xl font-extrabold text-ink">Page not found</h1>
+    <p class="mt-6 text-muted leading-relaxed">
+      The page you were looking for doesn't exist or may have moved. If you followed a
+      link to an older post, try the blog — many pages have new addresses.
+    </p>
+    <div class="mt-10 flex flex-wrap gap-4 justify-center">
+      <a href={withBase('/')} class="text-accent font-semibold">← Back home</a>
+      <a href={withBase('/blog')} class="text-accent font-semibold">Browse the blog →</a>
+    </div>
+  </section>
+</Base>

--- a/src/pages/privacy-policy.md
+++ b/src/pages/privacy-policy.md
@@ -1,0 +1,23 @@
+---
+layout: ../layouts/Prose.astro
+title: "Privacy Policy"
+description: "Devito Codes' policy regarding the collection, use and protection of any information gathered across our website."
+---
+
+Your privacy is important to us. It is Devito Codes's policy to respect your privacy regarding any information we may collect from you across our website, [https://www.devitocodes.com](https://www.devitocodes.com), and other sites we own and operate.
+
+We only ask for personal information when we truly need it to provide a service to you. We collect it by fair and lawful means, with your knowledge and consent. We also let you know why we're collecting it and how it will be used.
+
+We only retain collected information for as long as necessary to provide you with your requested service. What data we store, we'll protect within commercially acceptable means to prevent loss and theft, as well as unauthorized access, disclosure, copying, use or modification.
+
+We don't share any personally identifying information publicly or with third-parties, except when required to by law.
+
+Our website may link to external sites that are not operated by us. Please be aware that we have no control over the content and practices of these sites, and cannot accept responsibility or liability for their respective privacy policies.
+
+You are free to refuse our request for your personal information, with the understanding that we may be unable to provide you with some of your desired services.
+
+Your continued use of our website will be regarded as acceptance of our practices around privacy and personal information. If you have any questions about how we handle user data and personal information, feel free to contact us.
+
+For a detailed account of how we handle personal data in compliance with the GDPR and the UK Data Protection Act, see our [Data Protection &amp; Privacy Policy](/Data_Protection_Policy).
+
+This policy is effective as of 13 January 2021.

--- a/src/pages/terms.md
+++ b/src/pages/terms.md
@@ -1,0 +1,49 @@
+---
+layout: ../layouts/Prose.astro
+title: "Terms of Service"
+description: "The terms and conditions of use governing access to the Devito Codes website."
+---
+
+## 1. Terms
+
+By accessing this Website, accessible from https://www.devitocodes.com, you are agreeing to be bound by these Website Terms and Conditions of Use and agree that you are responsible for the agreement with any applicable local laws. If you disagree with any of these terms, you are prohibited from accessing this site. The materials contained in this Website are protected by copyright and trade mark law.
+
+## 2. Use License
+
+Permission is granted to temporarily download one copy of the materials on Devito Codes Ltd's Website for personal, non-commercial transitory viewing only. This is the grant of a license, not a transfer of title, and under this license you may not:
+
+- modify or copy the materials;
+- use the materials for any commercial purpose or for any public display;
+- attempt to reverse engineer any software contained on Devito Codes Ltd's Website;
+- remove any copyright or other proprietary notations from the materials; or
+- transfer the materials to another person or "mirror" the materials on any other server.
+
+This will let Devito Codes Ltd terminate upon violations of any of these restrictions. Upon termination, your viewing right will also be terminated and you should destroy any downloaded materials in your possession whether it is in printed or electronic format.
+
+## 3. Disclaimer
+
+All the materials on Devito Codes's Website are provided "as is". Devito Codes Ltd makes no warranties, may it be expressed or implied, therefore negates all other warranties. Furthermore, Devito Codes Ltd does not make any representations concerning the accuracy or reliability of the use of the materials on its Website or otherwise relating to such materials or any sites linked to this Website.
+
+## 4. Limitations
+
+Devito Codes or its suppliers will not be held accountable for any damages that will arise with the use or inability to use the materials on Devito Codes's Website, even if Devito Codes or an authorized representative of this Website has been notified, orally or written, of the possibility of such damage. Some jurisdictions do not allow limitations on implied warranties or limitations of liability for incidental damages, so these limitations may not apply to you.
+
+## 5. Revisions and Errata
+
+The materials appearing on Devito Codes's Website may include technical, typographical, or photographic errors. Devito Codes will not promise that any of the materials in this Website are accurate, complete, or current. Devito Codes may change the materials contained on its Website at any time without notice. Devito Codes does not make any commitment to update the materials.
+
+## 6. Links
+
+Devito Codes has not reviewed all of the sites linked to its Website and is not responsible for the contents of any such linked site. The presence of any link does not imply endorsement by Devito Codes of the site. The use of any linked website is at the user's own risk.
+
+## 7. Site Terms of Use Modifications
+
+Devito Codes may revise these Terms of Use for its Website at any time without prior notice. By using this Website, you are agreeing to be bound by the current version of these Terms and Conditions of Use.
+
+## 8. Your Privacy
+
+Please read our [Privacy Policy](/privacy-policy).
+
+## 9. Governing Law
+
+Any claim related to Devito Codes's Website shall be governed by the laws of the United Kingdom without regard to its conflict of law provisions.


### PR DESCRIPTION
Phase 1 of the cutover plan (legacy Jekyll → Astro). These are the production-readiness changes that are **base-path-agnostic**, so the existing subpath preview keeps working while reviewing. The `BASE_PATH`/`SITE_URL` flip and the repo rename happen in a later step.

## What's in here
- **Recreated policy pages** — `src/pages/privacy-policy.md` and `src/pages/terms.md`, ported verbatim from the legacy Jekyll site, using the existing `Prose.astro` layout. Keeps the live `/privacy-policy` and `/terms` URLs working. Linked from the footer.
- **404 page** — `src/pages/404.astro` (the new site had none; GitHub Pages serves `/404.html`).
- **Blog redirects** — `astro.config.mjs` `redirects` maps all 15 legacy root `/:title` post URLs → new `/blog/<slug>/`. Astro emits static meta-refresh stubs (GitHub Pages-compatible) and prepends `base` automatically, so the same map is correct at the preview base and at root.
- **`public/CNAME`** = `www.devitocodes.com` (only *binds* once the domain is released from the legacy repo during the cutover window — harmless before then).
- **robots.txt** — added `Sitemap: https://www.devitocodes.com/sitemap-index.xml`.
- GA is already correct (`site.ts` ga4 `G-39F3JRV5HY`, matching legacy) — no change needed.

## Verification
`BASE_PATH=/ SITE_URL=https://www.devitocodes.com npm run build` → 26 pages; `dist/CNAME`, `dist/404.html`, `dist/privacy-policy/`, `dist/terms/` present; the 15 redirect stubs emitted (e.g. `/announcing-devito-pro-…/` → meta-refresh to `/blog/launch`); sitemap uses the custom-domain host.

Part of the cutover runbook in `~/.claude/plans/`. Next: Phase 2 (base/site env flip) + the timed rename/Pages-API cutover.