### PR TITLE
Add RSS feed + author redirects; refresh README post-cutover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# devitocodes-web
+# devitocodespro.github.io
 
-The new [Devito Codes](https://www.devitocodes.com) marketing website — a commercial
-site for **DevitoPRO**, built with **Astro + Tailwind CSS** and deployed on GitHub Pages.
+The [Devito Codes](https://www.devitocodes.com) marketing website — a commercial site
+for **DevitoPRO**, built with **Astro + Tailwind CSS** and served on GitHub Pages at
+**https://www.devitocodes.com**.
 
-This repo is the redesign of the current Jekyll site. It is kept separate so the live
-site (`devitocodespro/devitocodespro.github.io`) is never disturbed until cutover.
+This is the organization's user-pages repo (`devitocodespro/devitocodespro.github.io`),
+so it serves at the **root** of the custom domain. It replaced the previous Jekyll
+site (archived at `devitocodespro/devitocodespro.github.io-jekyll`) at the 2026-06-08
+cutover.
 
 ## Develop
 
@@ -20,29 +23,31 @@ npm run check      # astro check (types + diagnostics)
 
 - **Content lives once, design varies.** All copy/structured data is in `src/data/*.ts`
   and the blog collection (`src/content/blog/`, migrated from the Jekyll `_posts/`).
-  Components read that data, so design variants only change styling — not content.
+  Components read that data, so design changes only touch styling — not content.
 - **Token-driven theming.** `src/styles/tokens.css` defines semantic `--c-*` color
-  tokens; `src/styles/global.css` maps them to Tailwind utilities. Re-skinning a whole
-  variant is mostly a `tokens.css` swap. `tone="dark"` sections locally override the
-  tokens to drop self-contained dark bands into any palette.
+  tokens; `src/styles/global.css` maps them to Tailwind utilities. Re-skinning is
+  mostly a `tokens.css` swap. `tone="dark"` sections locally override the tokens to
+  drop self-contained dark bands into any palette.
 - **Base-path aware.** `BASE_PATH` (injected by CI) lets the same source serve at the
-  site root, under project pages (`/devitocodes-web/`), or under a preview subpath.
-  Use `withBase()` (`src/lib/url.ts`) for internal links/assets; Markdown image paths
-  are prefixed automatically by a rehype plugin in `astro.config.mjs`.
+  site root (production) or under a preview subpath. Use `withBase()` (`src/lib/url.ts`)
+  for internal links/assets; Markdown image paths are prefixed automatically by a
+  rehype plugin in `astro.config.mjs`.
+- **Legacy URL preservation.** `astro.config.mjs` `redirects` map the old Jekyll
+  permalinks — blog posts (`/:title` → `/blog/<slug>/`) and author pages
+  (`/authors/<name>` → `/about`) — to their new homes. `/privacy-policy` and `/terms`
+  are kept as pages. An RSS feed is published at `/feed.xml`.
 
 ## Deploy & previews (GitHub Pages only)
 
-- **Production-candidate:** push to `main` → `.github/workflows/deploy.yml` builds and
-  publishes to the root of `gh-pages` → <https://devitocodespro.github.io/devitocodes-web/>.
-- **Design previews:** push a `variant/**` branch → `.github/workflows/preview.yml`
-  builds it and publishes to `gh-pages/preview/<name>/` → a stable, shareable URL:
-  `https://devitocodespro.github.io/devitocodes-web/preview/<name>/`.
-
-At cutover the `devitocodes.com` custom domain is moved onto this repo's Pages site
-and the build base flips to `/`.
+- **Production:** push to `main` → `.github/workflows/deploy.yml` builds with
+  `BASE_PATH=/` and `SITE_URL=https://www.devitocodes.com` and publishes to the root of
+  `gh-pages` → <https://www.devitocodes.com>. A committed `public/CNAME` keeps the
+  custom domain bound; `public/.nojekyll` stops GitHub from Jekyll-processing `_astro/`.
+- **Previews:** push a `variant/**` (or `init/**`) branch → `.github/workflows/preview.yml`
+  builds it under `gh-pages/preview/<name>/` → a stable, shareable URL:
+  `https://www.devitocodes.com/preview/<name>/`.
 
 ## Conventions
 
-- **Never push to `main`** — all changes land via pull requests.
-- The three candidate designs live on `variant/dark-enterprise`, `variant/light-minimal`
-  and `variant/hybrid`.
+- **Never push to `main`** — all changes land via pull requests; the production deploy
+  fires on merge to `main`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -52,11 +52,20 @@ const blogRedirects = {
   '/benchmarking-devitopro-on-intel-xeon-6-processors': '/blog/granite',
 };
 
+// Legacy author profile pages (Jekyll `_authors/` collection, served at
+// `/authors/<name>`) have no equivalent on the new site — point them at /about.
+const authorRedirects = {
+  '/authors/ecaunt': '/about',
+  '/authors/fluporini': '/about',
+  '/authors/ggorman': '/about',
+  '/authors/mlouboutin': '/about',
+};
+
 export default defineConfig({
   site: SITE,
   base: BASE,
   trailingSlash: 'ignore',
-  redirects: blogRedirects,
+  redirects: { ...blogRedirects, ...authorRedirects },
   integrations: [sitemap()],
   markdown: { rehypePlugins: [rehypeBasePrefix] },
   vite: { plugins: [tailwindcss()] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "devitocodes-web",
       "version": "0.1.0",
       "dependencies": {
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
         "astro": "^6.3.7"
       },
@@ -171,6 +172,17 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -1346,6 +1358,18 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@oslojs/encoding": {
       "version": "1.1.0",
@@ -3115,6 +3139,44 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fdir": {
@@ -4901,6 +4963,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/piccolore": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/piccolore/-/piccolore-0.1.3.tgz",
@@ -5508,6 +5585,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/svgo": {
       "version": "4.0.1",
@@ -6344,6 +6433,21 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xxhash-wasm": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "check": "astro check"
   },
   "dependencies": {
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "astro": "^6.3.7"
   },

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -39,6 +39,7 @@ const ogImage = new URL(withBase(image), Astro.site).href;
     <link rel="icon" href={withBase('/favicon.ico')} sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href={withBase('/favicon-32x32.png')} />
     <link rel="icon" type="image/png" sizes="16x16" href={withBase('/favicon-16x16.png')} />
+    <link rel="alternate" type="application/rss+xml" title={`${site.name} blog`} href={withBase('/feed.xml')} />
 
     <meta property="og:type" content="website" />
     <meta property="og:site_name" content={site.name} />

--- a/src/pages/feed.xml.js
+++ b/src/pages/feed.xml.js
@@ -1,0 +1,23 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import { site } from '../data/site';
+
+// RSS feed at /feed.xml (the URL the legacy site's <head> advertised). Lists
+// published posts newest-first; drafts are excluded, matching the /blog index.
+export async function GET(context) {
+  const posts = (await getCollection('blog'))
+    .filter((p) => !p.data.draft)
+    .sort((a, b) => +new Date(b.data.date) - +new Date(a.data.date));
+
+  return rss({
+    title: site.name,
+    description: site.description,
+    site: context.site,
+    items: posts.map((p) => ({
+      title: p.data.title,
+      pubDate: p.data.date,
+      description: p.data.description ?? p.data.subtitle ?? '',
+      link: `/blog/${p.id}/`,
+    })),
+  });
+}


### PR DESCRIPTION
The two non-blocking follow-ups from the cutover.

- **RSS feed** at `/feed.xml` via `@astrojs/rss` — newest-first, drafts excluded (same filter as the `/blog` index), advertised with a `<link rel="alternate">` in the head. The legacy `<head>` referenced `/feed.xml` but `jekyll-feed` was commented out, so this is effectively a new feed.
- **Author redirects** — legacy `/authors/<name>` (ecaunt, fluporini, ggorman, mlouboutin) → `/about` (no author-page feature on the new site).
- **README** rewritten for the post-cutover reality: org user-pages repo serving at the root of www.devitocodes.com; legacy site archived as `…-jekyll`; preview URLs updated.

Verified: `BASE_PATH=/ … npm run build` → `/feed.xml` (10 items), 4 author redirect stubs (`url=/about`), feed link in head.