### PR TITLE
CI: lychee link-check workflow (+ fix 2 dead links)

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,61 @@
+name: Link check
+
+# Builds the site and checks every link (internal + external) in the output with
+# lychee. Runs on PRs to main (catch breakage before deploy), weekly (catch external
+# link rot), and on demand. Config — including bot-walled hosts to skip — is in
+# lychee.toml at the repo root.
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 7 * * 1' # Mondays 07:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write # so the scheduled run can open/update a tracking issue on failure
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Build (production URLs)
+        env:
+          BASE_PATH: /
+          SITE_URL: https://www.devitocodes.com
+        run: npm run build
+      - name: Restore lychee cache
+        uses: actions/cache@v4
+        with:
+          path: .lycheecache
+          key: lychee-${{ github.sha }}
+          restore-keys: lychee-
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --config lychee.toml
+            --cache --max-cache-age 1d
+            --root-dir "${{ github.workspace }}/dist"
+            "dist/**/*.html"
+          # Don't auto-fail; let the issue step run on scheduled failures. The job
+          # is failed explicitly below so PRs still show a red check.
+          fail: false
+      - name: Open an issue on scheduled failure
+        if: ${{ github.event_name == 'schedule' && steps.lychee.outputs.exit_code != 0 }}
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: Dead links detected on the website
+          content-filepath: ./lychee/out.md
+          labels: link-check, automated
+      - name: Fail the job if links are broken
+        if: ${{ steps.lychee.outputs.exit_code != 0 }}
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ yarn-error.log*
 
 # Claude local guidance — never commit (per machine policy)
 **/CLAUDE.md
+
+# lychee link checker (CI cache + report output)
+.lycheecache
+/lychee/

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,32 @@
+# Configuration for the lychee link checker (https://lychee.cli.rs),
+# run by .github/workflows/linkcheck.yml against the built site in dist/.
+
+# Hosts that reject automated/bot requests (403/999) or trip lychee's HTTP/2
+# client — all verified reachable in a real browser, so excluding them avoids
+# false failures. Revisit if any stop being linked from the site.
+exclude = [
+  # Social / login-walled
+  "linkedin\\.com",
+  "twitter\\.com",
+  "x\\.com",
+  "join\\.slack\\.com",
+  # Vendor sites with bot deterrents / HTTP-2 quirks (open fine in a browser)
+  "intel\\.com",
+  "amd\\.com",
+  "opencompute\\.org",
+  # Academic publishers (301 -> 403 to bots)
+  "library\\.seg\\.org",
+  "pubs\\.geoscienceworld\\.org",
+  # The 404 page's own canonical URL inherently 404s — not a real link
+  "www\\.devitocodes\\.com/404",
+]
+
+# Tolerate rate-limiting from hosts we do check (keeps CI from flaking); real
+# dead links (404/410/5xx/DNS) still fail the run.
+accept = [200, 206, 429]
+
+max_retries = 2
+retry_wait_time = 2
+timeout = 30
+
+user_agent = "Mozilla/5.0 (compatible; lychee; +https://www.devitocodes.com)"

--- a/src/content/blog/IM.md
+++ b/src/content/blog/IM.md
@@ -84,7 +84,7 @@ real-world seismic challenges.
 ## Applying to Land Seismic Data
 
 We are collaborating with service companies like
-[S-Cube](https://www.s-cube.com/partnerships/xwi-plus-devito/) to apply these methods to
+[S-Cube](https://www.s-cube.com/) to apply these methods to
 real-world land seismic applications. Accurately modeling acoustic and elastic
 TTI wavefield behavior in environments with pronounced and irregular topography
 is essential. Our immersed boundary method effectively captures topographic

--- a/src/content/blog/thematrix.md
+++ b/src/content/blog/thematrix.md
@@ -31,7 +31,7 @@ configurations.
 TheMatrix is the most comprehensive apples-to-apples comparison of the
 performance of seismic imaging workloads yet to be published. You can dive
 straight into one of the TheMatrix [auto-generated
-plots](https://www.devitoproject.org/thematrix/#acoustic_iso.IsotropicAcousticForward.track_gpointss)!
+plots](https://www.devitoproject.org/)!
 This plot shows the performance of the 3D isotropic acoustic equation, a basic
 benchmark used by the seismic imaging community. **Gigapoints per second** is
 used as the performance metric as it is widely used in the O&G sector to


### PR DESCRIPTION
Wires **`lycheeverse/lychee-action`** into CI for dead-link detection, and fixes the two genuine dead links the checker surfaced.

## Workflow — `.github/workflows/linkcheck.yml`
Builds the site (`BASE_PATH=/`, `SITE_URL=https://www.devitocodes.com`) and runs lychee over `dist/**/*.html` (every page, every internal + external link). Triggers:
- **`pull_request` → main** — catch breakage before it deploys (this PR runs it on itself).
- **`schedule`** — weekly (Mon 07:00 UTC) to catch external link rot; opens a tracking issue on failure.
- **`workflow_dispatch`** — on demand.

Caches results (`.lycheecache`) and fails the job on real broken links.

## Config — `lychee.toml`
Excludes hosts that block bots / trip lychee's HTTP/2 client but are fine in a browser — Intel, AMD, OpenCompute, SEG / GeoScienceWorld, LinkedIn/X/Slack — plus the 404 page's self-canonical; tolerates `429`. Real failures (404/410/5xx/DNS) still fail.

## Dead links fixed (found during validation)
- `blog/IM`: `s-cube.com/partnerships/xwi-plus-devito/` (whole `/partnerships` section is 404) → `s-cube.com` home.
- `blog/thematrix`: the retired `devitoproject.org/thematrix/#…` benchmark dashboard (404) → `devitoproject.org`. *(Repoint to a better target if the dashboard now lives elsewhere.)*

## Verified locally
`lychee --config lychee.toml --root-dir dist 'dist/**/*.html'` → **0 errors** (1031 OK, 50 excluded).