### PR TITLE
Landing page: drop "finite difference" from the copy

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -42,7 +42,7 @@ const cols = [
         </div>
         <p class="mt-4 text-sm text-muted leading-relaxed max-w-xs">
           The commercial arm of the open-source Devito project — performance-portable
-          finite-difference HPC for seismic imaging.
+          seismic imaging.
         </p>
         <div class="mt-5 flex gap-4 text-muted">
           <a href={site.social.github} target="_blank" rel="noopener noreferrer" class="hover:text-ink">GitHub</a>

--- a/src/data/content.ts
+++ b/src/data/content.ts
@@ -109,7 +109,7 @@ export const useCases = {
     { title: 'Embed in your stack', body: 'Call DevitoPRO from applications in other languages through the Decoupler API, with full MPI support, and integrate generated propagators into existing inversion engines.' },
     { title: 'Very large models', body: 'Run models beyond the limits of in-house codes using compression, data streaming, expanding-box and mixed precision to keep memory and transfer costs in check.' },
     { title: 'Cloud-native seismic imaging', body: 'Tuned, benchmarked deployments on AWS, Azure and GCP — portable across available instances.' },
-    { title: 'Immersed-boundary topography', body: 'Accurate land topography on finite-difference grids via immersed boundary support.' },
+    { title: 'Immersed-boundary topography', body: 'Accurate land topography via immersed-boundary support on the simulation grid.' },
     { title: 'Time-lapse (4D) monitoring', body: 'Production workflows for repeat surveys — scale imaging and inversion consistently across vintages.' },
     { title: 'Least-squares imaging (LS-RTM) & variants', body: 'Iterative imaging and imaging-condition variants built from the same symbolic building blocks.' },
   ],
@@ -137,7 +137,7 @@ export const caseStudies = [
     outlet: 'Intel Customer Spotlight',
     date: '2024-11-04',
     href: 'https://www.intel.com/content/www/us/en/customer-spotlight/stories/devito-codes-customer-story.html',
-    body: 'How Devito Codes helps customers resolve the HPC trilemma — performance, portability and productivity — generating optimized finite-difference code from a Python DSL.',
+    body: 'How Devito Codes helps customers resolve the HPC trilemma — performance, portability and productivity — generating optimized native code from a Python DSL.',
     external: true,
   },
   {
@@ -161,7 +161,7 @@ export const caseStudies = [
     outlet: 'Microsoft Research',
     date: '2022-03-03',
     href: 'https://www.microsoft.com/en-us/research/video/devito-workshop-at-2022-rice-energy-high-performance-computing-conference/',
-    body: 'A workshop and hackathon introducing Devito — the DSL and code-generation framework for highly optimized finite-difference kernels such as FWI and RTM — run on Azure CPU and GPU instances, with lightning talks illustrating Devito from end-user, cloud-provider, hardware and academic perspectives.',
+    body: 'A workshop and hackathon introducing Devito — the DSL and code-generation framework for highly optimized FWI and RTM kernels — run on Azure CPU and GPU instances, with lightning talks illustrating Devito from end-user, cloud-provider, hardware and academic perspectives.',
     external: true,
   },
 ];

--- a/src/data/features.ts
+++ b/src/data/features.ts
@@ -8,7 +8,7 @@ export interface FeatureCategory { name: string; rows: FeatureRow[]; }
 
 export const featureIntro =
   'DevitoPRO extends open-source Devito for production seismic imaging and inversion. ' +
-  'Both express finite-difference kernels symbolically; DevitoPRO adds the tuning, ' +
+  'Both let you express PDE solvers symbolically; DevitoPRO adds the tuning, ' +
   'portability and enterprise support needed for production HPC workflows.';
 
 // Curated headline capabilities — the primary view on /features.

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -10,7 +10,7 @@ export const site = {
 
   description:
     'DevitoPRO — production-grade code generation for seismic imaging and ' +
-    'finite-difference HPC. Symbolic Python in, optimized native CPU/GPU kernels out.',
+    'high-performance computing. Symbolic Python in, optimized native CPU/GPU kernels out.',
 
   social: {
     github: 'https://github.com/devitocodes',


### PR DESCRIPTION
Addresses Fabio's review note: *"remove every single instance of 'finite difference' in the landing page — it makes us look too small."*

Removes the narrow numerical-method term from the landing page + shared marketing copy, leaning on broader framing (seismic imaging, PDE solvers, HPC). His suggested footer wording is used verbatim.

| Where | Before → After |
|---|---|
| Footer tagline (site-wide) | `…performance-portable finite-difference HPC for seismic imaging.` → `…performance-portable seismic imaging.` |
| Meta/OG description (`site.ts`) | `…seismic imaging and finite-difference HPC.` → `…seismic imaging and high-performance computing.` |
| Capabilities intro (`featureIntro`) | `express finite-difference kernels symbolically` → `express PDE solvers symbolically` |
| Immersed-boundary use case | `on finite-difference grids via immersed boundary support` → `via immersed-boundary support on the simulation grid` |
| Intel case-study card | `optimized finite-difference code from a Python DSL` → `optimized native code from a Python DSL` |
| Microsoft case-study card | `highly optimized finite-difference kernels such as FWI and RTM` → `highly optimized FWI and RTM kernels` |

Shared strings, so this also cleans the `/features` intro and `/case-studies` cards.

**Verified** (`BASE_PATH=/ … npm run build`): `finite` count is **0** on `dist/index.html`, `dist/case-studies/index.html`, and `dist/features/index.html`. After this, the term no longer appears anywhere on the live site except the two `/about` team bios (left intact by choice — they describe real PhD/research) and an unused `featureCategories` table heading that isn't rendered.

Out of scope: `/about` team bios, dated blog posts.